### PR TITLE
correct mailto link on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
                     <tr>
                         <td><svg class="la-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="M 3 8 L 3 26 L 29 26 L 29 8 Z M 7.3125 10 L 24.6875 10 L 16 15.78125 Z M 5 10.875 L 15.4375 17.84375 L 16 18.1875 L 16.5625 17.84375 L 27 10.875 L 27 24 L 5 24 Z"/></svg></td>
                         <td>
-                            <a href="mailto://ndlug@nd.edu">ndlug@nd.edu</a>
+                            <a href="mailto:ndlug@nd.edu">ndlug@nd.edu</a>
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
`mailto:` URIs don't need `//` as do regular links: https://en.wikipedia.org/wiki/Mailto.